### PR TITLE
Implement basic NLP process endpoint with frontend demo

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,15 @@
 from fastapi import FastAPI
+from .schemas import ProcessRequest, ProcessResponse
+from .nlp_pipeline import process_text
 
 app = FastAPI(title="Neuro-Canvas API")
 
 @app.get("/")
 def read_root():
     return {"message": "Hello from Neuro-Canvas API"}
+
+
+@app.post("/api/v1/process", response_model=ProcessResponse)
+def process_endpoint(payload: ProcessRequest):
+    """Process input text and return token information."""
+    return process_text(payload.text)

--- a/backend/app/nlp_pipeline.py
+++ b/backend/app/nlp_pipeline.py
@@ -1,0 +1,32 @@
+import spacy
+from yake import KeywordExtractor
+
+nlp = spacy.blank("en")
+keyword_extractor = KeywordExtractor()
+
+POS_COLOR_MAP = {
+    "NOUN": "red",
+    "VERB": "blue",
+    "ADJ": "green",
+}
+
+
+def get_color_tag(pos: str) -> str:
+    return POS_COLOR_MAP.get(pos, "gray")
+
+
+def process_text(text: str):
+    doc = nlp(text)
+    keywords = {kw[0] for kw in keyword_extractor.extract_keywords(text)}
+    processed = []
+    for token in doc:
+        processed.append({
+            "token": token.text,
+            "pos": token.pos_,
+            "is_keyword": token.text in keywords,
+            "color_tag": get_color_tag(token.pos_),
+            "lemma": token.lemma_,
+            "char_start": token.idx,
+            "char_end": token.idx + len(token.text),
+        })
+    return {"original_text": text, "processed_data": processed}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,19 @@
+from pydantic import BaseModel
+from typing import List, Optional
+
+class ProcessRequest(BaseModel):
+    text: str
+    config: Optional[dict] = None
+
+class TokenData(BaseModel):
+    token: str
+    pos: str
+    is_keyword: bool
+    color_tag: str
+    lemma: str
+    char_start: int
+    char_end: int
+
+class ProcessResponse(BaseModel):
+    original_text: str
+    processed_data: List[TokenData]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+spacy
+yake

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,10 +1,43 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { processText } from './api';
+
+function TokenView({ data }) {
+  return (
+    <span style={{ color: data.color_tag, marginRight: '4px' }}>
+      {data.token}
+    </span>
+  );
+}
 
 export default function App() {
+  const [text, setText] = useState('');
+  const [tokens, setTokens] = useState([]);
+
+  const handleProcess = async () => {
+    try {
+      const result = await processText(text);
+      setTokens(result.processed_data);
+    } catch (err) {
+      alert(err.message);
+    }
+  };
+
   return (
     <div>
       <h1>Neuro-Canvas</h1>
-      <p>Welcome to the visualization tool.</p>
+      <textarea
+        rows="6"
+        cols="60"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+      />
+      <br />
+      <button onClick={handleProcess}>Process</button>
+      <div style={{ marginTop: '1rem' }}>
+        {tokens.map((t, idx) => (
+          <TokenView key={idx} data={t} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,0 +1,11 @@
+export async function processText(text) {
+  const response = await fetch('/api/v1/process', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text })
+  });
+  if (!response.ok) {
+    throw new Error('Failed to process text');
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- add FastAPI endpoint `/api/v1/process`
- implement simple NLP pipeline using spaCy and YAKE
- define Pydantic schemas
- expose small API utility and textarea demo in React frontend

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6847054ef73c8329a051f7346c1d78a4