### PR TITLE
Implement unit tests for backend

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 spacy
 yake
+pytest

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+from app.main import app
+
+client = TestClient(app)
+
+def test_process_endpoint():
+    resp = client.post('/api/v1/process', json={'text': 'Hello world'})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data['original_text'] == 'Hello world'
+    assert isinstance(data['processed_data'], list)
+
+
+def test_create_and_get_canvas():
+    canvas_payload = {
+        'name': 'Test Canvas',
+        'canvas_state': {'tokens': []}
+    }
+    create_resp = client.post('/api/v1/canvases', json=canvas_payload)
+    assert create_resp.status_code == 201
+    canvas_data = create_resp.json()
+    canvas_id = canvas_data['id']
+
+    get_resp = client.get(f'/api/v1/canvases/{canvas_id}')
+    assert get_resp.status_code == 200
+    fetched = get_resp.json()
+    assert fetched['id'] == canvas_id
+    assert fetched['name'] == 'Test Canvas'

--- a/backend/tests/test_nlp_pipeline.py
+++ b/backend/tests/test_nlp_pipeline.py
@@ -1,0 +1,16 @@
+import pytest
+from app.nlp_pipeline import process_text
+
+def test_process_text_basic():
+    text = "Hello world."
+    result = process_text(text)
+    assert result["original_text"] == text
+    tokens = result["processed_data"]
+    assert any(t["token"].lower() == "hello" for t in tokens)
+    assert any(t["token"].lower() == "world" for t in tokens)
+    # check that keywords and color tags exist
+    for t in tokens:
+        assert "is_keyword" in t
+        assert "color_tag" in t
+        assert "pos" in t
+        assert "lemma" in t

--- a/developer_spec.md
+++ b/developer_spec.md
@@ -147,7 +147,7 @@
 * [x] 整合 spaCy 進行分句、分詞與詞性標註。
 * [x] 整合 YAKE (或其他庫) 進行關鍵詞提取。
 * [x] 編寫邏輯：根據詞性 (POS) 標註，為關鍵詞分配預設的 `color_tag`。
-* [ ] 撰寫單元測試，確保 NLP pipeline 的輸出穩定。
+* [x] 撰寫單元測試，確保 NLP pipeline 的輸出穩定。
 * **前端任務 (Frontend Engineer):**
     * [x] 建立 React 專案結構。
     * [x] 創建一個文本輸入組件 (`<textarea>` 或支援 `.txt` / `.md` 文件上傳)。


### PR DESCRIPTION
## Summary
- add `pytest` to backend dependencies
- implement backend unit tests for NLP pipeline and API
- mark testing task as completed in developer spec

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi & spacy)*

------
https://chatgpt.com/codex/tasks/task_e_6847197fa4f08329bb03112698e3f74b